### PR TITLE
EN-46379 - Fix minimist vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function CartoMML(styleData) {
     return { 'name': name };
   });
 
-  this.Stylesheet = [ { data: styleData } ];
+  this.Stylesheet = [ { id: 'stylesheet', data: styleData } ];
 
   this.xml = renderer.render(this).toString() + '\n';
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "chai": "^4.0.1",
     "jsonfile": "^3.0.0",
-    "mocha": "^3.4.2",
+    "mocha": "^9.0.0",
     "prompt": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "body-parser": "^1.13.3",
     "bunyan": "^1.4.0",
-    "carto": "^0.14.1",
+    "carto": "^0.16.0",
     "express": "^4.13.3"
   },
   "eslintConfig": {


### PR DESCRIPTION
With the changes in #10 + updating mocha, all minimist dependencies are 1.2.2 or later